### PR TITLE
Fix repository in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT"
 description = "libbtrfsutil bindings"
 readme = "README.md"
-repository = "https://github.com/zhangyuannie/butter"
+repository = "https://github.com/zhangyuannie/libbtrfsutil-rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Cargo.toml points to the `butter` repository, rather than this repository.