### PR TITLE
fix: make `ErrorKind` visible outside the library

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ use std::{
     path::Path,
 };
 
-pub use error::Error;
+pub use error::{Error, ErrorKind};
 pub use qgroup::QgroupInherit;
 pub use subvol::*;
 pub const FS_TREE_OBJECTID: u64 = 5;


### PR DESCRIPTION
While the struct `ErrorKind` is defined as `pub` inside the module `error`, the module itself is private.
In contrast to the struct `Error`, `ErrorKind` is not exported by a `pub use` in `lib.rs`, effectively making it invisible outside the library and impeding fine-grained error handling.

This change fixes this by exporting `ErrorKind` alongside `Error`.